### PR TITLE
ADD official support for Python 3.10

### DIFF
--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_and_linting.yml
+++ b/.github/workflows/tests_and_linting.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        # Python versions need to be strings (otherwise: 3.10 -> 3.1)
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+[1.2.2] - 2021-12-11
+--------------------
+- [ADDED] Official support for Python 3.10.
+- [REMOVED] Official support for Python 3.6 (will be deprecated end of 2021
+  anyways). It might still work, but will not be maintained on this version.
+
 [1.2.1] - 2021-10-19
 --------------------
 - [ADDED] Quantization error `get_quantization_error()`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,9 +5,9 @@ authors:
     given-names: Felix M.
     orcid: https://orcid.org/0000-0003-0596-9585
 title: "SuSi: SUpervised Self-organIzing maps in Python"
-version: 1.2.1
+version: 1.2.2
 doi: "10.5281/zenodo.2609130"
-date-released: 2021-10-19
+date-released: 2021-12-11
 repository-code: https://github.com/felixriese/susi
 license: BSD-3-Clause
 preferred-citation:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ author = "Felix M. Riese"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "1.2.1"
+release = "1.2.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/meta.yaml
+++ b/meta.yaml
@@ -18,11 +18,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python >=3.7
   run:
     - joblib >=0.13.0
     - numpy >=1.18.5
-    - python >=3.6
+    - python >=3.7
     - scikit-learn >=0.21.1
     - scipy >=1.3.1
     - tqdm >=4.45.0

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "susi" %}
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
 
 
 package:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ nbval>=0.9.5
 coverage>=5.3
 
 # for formatting
-black
+black>=21.9b0
 
 # for the documentation
 sphinx>=3.3.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = "\n\n".join((readme, changelog))
 
 setuptools.setup(
     name="susi",
-    version="1.2.1",
+    version="1.2.2",
     author="Felix M. Riese",
     author_email="github@felixriese.de",
     description=(

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
@@ -61,5 +61,5 @@ setuptools.setup(
         "Source": "https://github.com/felixriese/susi",
         "Tracker": "https://github.com/felixriese/susi/issues",
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/susi/__init__.py
+++ b/susi/__init__.py
@@ -4,7 +4,7 @@ Python package for unsupervised, supervised and semi-supervised
 self-organizing maps (SOM).
 
 """
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 from .SOMClassifier import SOMClassifier
 from .SOMClustering import SOMClustering


### PR DESCRIPTION
## Changes
- [ADDED] Official support for Python 3.10.
- [REMOVED] Official support for Python 3.6 (will be deprecated end of 2021 anyways). It might still work, but will not be maintained on this version.